### PR TITLE
fix measures array bug

### DIFF
--- a/src/query.js
+++ b/src/query.js
@@ -97,6 +97,9 @@ var Query = function(appId, config) {
 
   _.extend(this.config, config);
   
+  if (!_.isArray(this.config.measures)) {
+    this.config.measures = [this.config.measures];
+  }
   if (this.config.group) {
     this.config.group = _.extend({ 
       metric: this.config.measures[0], 


### PR DESCRIPTION
This update is supposed to fix the bug where the query constructor function would fail, if used with grouping option and a single metric.